### PR TITLE
chore: replace all Shen Lab references with LabClaw

### DIFF
--- a/.claude/agents/neuro-specialist.md
+++ b/.claude/agents/neuro-specialist.md
@@ -21,7 +21,7 @@ You ensure the system speaks the language of neuroscience. Your responsibilities
 - Ensure closed-loop optimization targets are scientifically meaningful and safe
 
 Key neuroscience tools you integrate:
-- **SAM-Behavior**: Zero-shot multi-animal pose estimation (Shen Lab, primary video analysis)
+- **SAM-Behavior**: Zero-shot multi-animal pose estimation (primary video analysis)
 - **DeepLabCut**: Markerless pose estimation (alternative/validation)
 - **Suite2p**: Two-photon calcium imaging analysis
 - **Kilosort**: Spike sorting for electrophysiology

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ Before submitting a pull request, verify:
 - **Graphiti**: `graphiti-core` — temporal knowledge graph for lab memory
 - **NWB**: `pynwb` + `hdmf` — Neurodata Without Borders export
 - **NeuroConv**: Format conversion from 47+ neuroscience formats
-- **SAM-Behavior**: Zero-shot multi-animal pose estimation (Shen Lab)
+- **SAM-Behavior**: Zero-shot multi-animal pose estimation ()
 - **watchdog**: File system monitoring for edge nodes
 - **scikit-optimize**: Bayesian optimization engine
 - **sentence-transformers**: Embedding model for memory search

--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Shen Lab
+   Copyright 2026 LabClaw Team
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@
 
 ## v0.0.5 — First Discovery (C1: DISCOVER)
 
-- Real Shen Lab behavioral data through the pipeline
+- Real behavioral data through the pipeline
 - Claude API hypothesis generation with cost guard (`--max-llm-calls N`)
 - First real ValidationReport with p-values
 - First automated MEMORY.md entry from discovery

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@
 
 **Do NOT open a public GitHub issue for security vulnerabilities.**
 
-Please report security issues via email to: **security@shenlab.org**
+Please report security issues via email to: **security@labclaw.org**
 
 Include:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -519,7 +519,7 @@ List all registered plugins.
     "name": "labclaw-neuro",
     "version": "0.1.0",
     "description": "Neuroscience domain plugin",
-    "author": "Shen Lab",
+    "author": "LabClaw Team",
     "plugin_type": "domain"
   }
 ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,7 +194,7 @@ edge:
 
 ```yaml
 system:
-  name: shen-lab
+  name: labclaw
   log_level: WARNING
 
 graph:

--- a/docs/index.md
+++ b/docs/index.md
@@ -199,6 +199,6 @@ LabClaw v0.1.0 demonstrates five core capabilities with reproducible benchmarks:
 
 <div style="text-align: center; padding: 1em 0;">
 <p style="font-size: 0.9em; color: var(--md-default-fg-color--light);">
-LabClaw is developed by <a href="https://github.com/labclaw">Shen Lab</a> and released under the Apache 2.0 license.
+LabClaw is developed by <a href="https://github.com/labclaw">LabClaw Team</a> and released under the Apache 2.0 license.
 </p>
 </div>

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -43,12 +43,12 @@ Contains YAML frontmatter and markdown body describing an entity's identity:
 
 ```markdown
 ---
-name: Shen Lab
+name: LabClaw
 type: lab
 created: 2026-01-15
 ---
 
-# Shen Lab
+# LabClaw
 
 ## Identity
 
@@ -88,7 +88,7 @@ backend = TierABackend(Path("lab"))
 
 # Read SOUL.md
 soul = backend.read_soul("lab")
-print(soul.frontmatter)  # {"name": "Shen Lab", "type": "lab", ...}
+print(soul.frontmatter)  # {"name": "LabClaw", "type": "lab", ...}
 print(soul.content)       # Markdown body
 
 # Write SOUL.md

--- a/docs/plans/2026-02-24-v004-foundation.md
+++ b/docs/plans/2026-02-24-v004-foundation.md
@@ -834,7 +834,7 @@ git commit -m "test(hardware): 100% coverage for drivers and interfaces"
 
 **Step 1: Create behavioral CSV data**
 
-Mimics real Shen Lab format: timestamp, x, y, speed, angle, zone, animal_id.
+Mimics real behavioral data format: timestamp, x, y, speed, angle, zone, animal_id.
 50 rows per file, 2 sessions. Data has:
 - A real correlation (speed ~ distance_from_center)
 - A temporal trend (speed increases over time)
@@ -1042,7 +1042,7 @@ Reference `docs/plans/2026-02-24-v004-to-v010-roadmap.md` for details. ROADMAP.m
 - `labclaw pipeline --once` CLI command
 
 ## v0.0.5 — First Discovery
-- Real Shen Lab behavioral data through pipeline
+- Real behavioral data through pipeline
 - Claude API hypothesis generation with cost guard
 - First real ValidationReport with p-values
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ LabClaw's core architecture is **domain-agnostic** — the plugin system support
 ## Current Status (v0.0.2)
 
 - **Core:** Domain-agnostic engine with 5-layer stack
-- **Built-in domains:** Generic, Neuroscience (shenlab domain pack)
+- **Built-in domains:** Generic, Neuroscience (built-in domain pack)
 - **Plugin types:** DevicePlugin, DomainPlugin, AnalysisPlugin
 
 ## Domain Plugin Architecture
@@ -30,7 +30,7 @@ These domains have clear data formats and the highest demand.
 
 | Domain | Key Instruments | Data Types | Status |
 |--------|----------------|------------|--------|
-| **Neuroscience** | Two-photon, EEG, behavioral rigs | TIFF, NWB, CSV, video | **Built** (shenlab) |
+| **Neuroscience** | Two-photon, EEG, behavioral rigs | TIFF, NWB, CSV, video | **Built**  |
 | **Molecular Biology** | qPCR, gel imager, plate reader | CSV, TIFF, absorbance | **Partial** (qPCR driver exists) |
 | **Chemistry** | Spectrometers, HPLC, LC-MS | CSV, mzML, JCAMP-DX | Planned |
 | **Materials Science** | SEM, XRD, tensile testing | TIFF, CSV, CIF | Planned |

--- a/docs/specs/L4-memory.md
+++ b/docs/specs/L4-memory.md
@@ -168,12 +168,12 @@ Events are registered at module import time via the global `event_registry`.
 
 ```markdown
 ---
-name: Shen Lab
+name: LabClaw
 type: lab
 created: 2026-02-19T00:00:00Z
 ---
 
-# Shen Lab
+# LabClaw
 
 Mission, values, and identity description...
 ```

--- a/lab/SOUL.md
+++ b/lab/SOUL.md
@@ -1,6 +1,6 @@
 # Lab Identity
 
-**Lab:** Shen Lab
+**Lab:** LabClaw
 **Domain:** Behavioral neuroscience + brain imaging
 **Instruments:** Video cameras, microscopes, electrophysiology rigs, behavioral apparatus
 **Core values:** Reproducibility first, data before story, rigorous statistics, open science

--- a/members/labclaw-intern/MEMORY.md
+++ b/members/labclaw-intern/MEMORY.md
@@ -14,7 +14,7 @@
 
 ## Project History
 
-- 2026-02: Deployed as first digital intern for Shen Lab
+- 2026-02: Deployed as first digital intern for LabClaw
 
 ## Performance Log
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [
-    { name = "Shen Lab" },
+    { name = "LabClaw Team" },
 ]
 
 dependencies = [

--- a/tests/features/layer4_memory/markdown_memory.feature
+++ b/tests/features/layer4_memory/markdown_memory.feature
@@ -10,10 +10,10 @@ Feature: Markdown Memory (Tier A)
   # -----------------------------------------------------------------------
 
   Scenario: Create and read an entity's SOUL.md
-    When I create a SOUL for entity "shen-lab" with name "Shen Lab"
-    And I request the SOUL for entity "shen-lab"
+    When I create a SOUL for entity "labclaw" with name "LabClaw"
+    And I request the SOUL for entity "labclaw"
     Then I receive a MarkdownDoc with frontmatter containing "name"
-    And the frontmatter "name" is "Shen Lab"
+    And the frontmatter "name" is "LabClaw"
     And the content is valid markdown
     And an event "memory.tier_a.created" is emitted
 


### PR DESCRIPTION
## Summary

- Replace all 23 occurrences of "research lab" / "labdemo" / "shen-lab" across 16 files
- Use "LabClaw Team" for authorship (pyproject, LICENSE, API docs)
- Use "LabClaw" for lab identity (SOUL.md, memory, BDD fixtures)
- Update security contact to security@labclaw.org

## Test plan

- [x] `grep -ri labdemo` returns zero matches
- [x] 2161 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)