### PR TITLE
docs: default to light mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,15 +8,13 @@ edit_uri: edit/main/docs/
 theme:
   name: material
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
+    - scheme: default
       primary: deep purple
       accent: amber
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
+    - scheme: slate
       primary: deep purple
       accent: amber
       toggle:


### PR DESCRIPTION
Remove media queries from MkDocs palette so light theme is always the default, regardless of OS preference. Toggle still available.