### PR TITLE
docs: fix display issues and stale content

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ events:
   redis_url: redis://localhost:6379
 
 api:
-  host: 0.0.0.0
+  host: 127.0.0.1
   port: 8000
 
 edge:
@@ -87,7 +87,7 @@ REST API server settings.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `host` | string | `"0.0.0.0"` | Bind address |
+| `host` | string | `"127.0.0.1"` | Bind address |
 | `port` | int | `8000` | Listen port |
 
 Note: The daemon uses `--port` (default 18800), which overrides this value.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -40,7 +40,7 @@ my-lab/
 Open `lab/SOUL.md` and describe your lab:
 
 ```markdown
-# Shen Neuroscience Lab
+# My Neuroscience Lab
 
 ## Identity
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,10 +14,11 @@ Each domain plugin provides:
 
 ```python
 class DomainPlugin(Protocol):
-    def sample_types(self) -> list[type[GraphNode]]: ...
-    def sentinel_rules(self) -> list[SentinelRule]: ...
-    def hypothesis_templates(self) -> list[str]: ...
-    def analysis_defaults(self) -> dict[str, Any]: ...
+    metadata: PluginMetadata
+
+    def get_sample_node_types(self) -> dict[str, type]: ...
+    def get_sentinel_rules(self) -> list[dict[str, Any]]: ...
+    def get_hypothesis_templates(self) -> list[dict[str, Any]]: ...
 ```
 
 A new domain = **< 100 lines** of Python to define sample types, safety rules, and analysis defaults.
@@ -127,19 +128,17 @@ class MyDomainPlugin:
         name="labclaw-my-domain",
         version="0.1.0",
         description="My science domain for LabClaw",
+        plugin_type="domain",
     )
 
-    def sample_types(self):
-        return [MySampleNode]
+    def get_sample_node_types(self):
+        return {"my_sample": MySampleNode}
 
-    def sentinel_rules(self):
-        return [MyQualityRule()]
+    def get_sentinel_rules(self):
+        return [{"name": "quality_check", "condition": {...}}]
 
-    def hypothesis_templates(self):
-        return ["If {condition}, then {outcome} because {mechanism}"]
-
-    def analysis_defaults(self):
-        return {"correlation_threshold": 0.5}
+    def get_hypothesis_templates(self):
+        return [{"template": "If {condition}, then {outcome}", "required_evidence": ["correlation"]}]
 ```
 
 ## Community Contribution Model

--- a/docs/specs/L4-memory.md
+++ b/docs/specs/L4-memory.md
@@ -122,7 +122,7 @@ Events are registered at module import time via the global `event_registry`.
 ## Boundary Contracts
 
 - All timestamps MUST be timezone-aware UTC.
-- Entity IDs MUST match regex `[A-Za-z0-9][A-Za-z0-9._-]{0,127}`.
+- Entity IDs MUST match regex `\[A-Za-z0-9\]\[A-Za-z0-9._-\]{0,127}`.
 - SOUL.md MUST have valid YAML frontmatter between `---` markers.
 - MEMORY.md entries are append-only; entries are never deleted or modified.
 - File paths are `pathlib.Path` objects throughout.
@@ -148,7 +148,7 @@ Events are registered at module import time via the global `event_registry`.
 | `read_memory()` for nonexistent entity | `FileNotFoundError` | Includes entity_id and expected path |
 | SOUL.md with malformed YAML frontmatter | `ValueError` | Includes parse error details |
 | Empty entity_id | `ValueError` | "entity_id must be non-empty" |
-| Invalid entity_id format | `ValueError` | "entity_id must match [A-Za-z0-9][A-Za-z0-9._-]{0,127}" |
+| Invalid entity_id format | `ValueError` | "entity_id must match `\[A-Za-z0-9\]\[A-Za-z0-9._-\]{0,127}`" |
 | API search `limit < 1` | HTTP `422` | FastAPI validation error (query parameter `limit`) |
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,3 +106,6 @@ nav:
   - API Reference:
       - REST API: api-reference.md
       - Python API: reference/python-api.md
+      - CI/CD: reference/ci-cd.md
+  - Migrations:
+      - "2026-02-20 API Changes": migrations/2026-02-20-api-behavior-changes.md


### PR DESCRIPTION
## Summary
- Update default API host from `0.0.0.0` to `127.0.0.1` in configuration docs (matches security hardening in `configs/default.yaml`)
- Remove remaining "Shen Neuroscience Lab" reference in cookbook example
- Fix `DomainPlugin` protocol signatures in roadmap to match actual API (`get_sample_node_types`, `get_sentinel_rules`, `get_hypothesis_templates`)
- Escape regex pattern in L4-memory spec to suppress mkdocs autorefs warning
- Add orphaned CI/CD and Migrations pages to mkdocs nav

## Test plan
- [x] `uv run mkdocs build` passes with zero warnings
- [x] All 28 docs pages included in nav (only internal `plans/` excluded)
- [x] No remaining "Shen" references in docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)