### PR TITLE
chore: rename members/shen to members/pi

### DIFF
--- a/members/pi/MEMORY.md
+++ b/members/pi/MEMORY.md
@@ -1,4 +1,4 @@
-# Shen — Personal Memory
+# PI — Personal Memory
 
 > Accumulated by LabClaw over time.
 

--- a/members/pi/SOUL.md
+++ b/members/pi/SOUL.md
@@ -1,8 +1,8 @@
-# Shen — PI
+# PI
 
 ## Identity
 
-- **Name:** Shen
+- **Name:** PI
 - **Role:** PI
 - **Language:** Chinese for discussion, English for data/code
 


### PR DESCRIPTION
## Summary
- Rename `members/shen/` directory to `members/pi/`
- Update SOUL.md and MEMORY.md headings to use "PI" instead of "Shen"
- Zero "Shen"/"shen" references remain in the entire codebase

## Test plan
- [x] `grep -ri shen` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)