### PR TITLE
chore: revert project version to 0.0.10

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,9 +43,9 @@
 - Structured JSON logging
 - Enhanced `/health` endpoint (component status, last cycle time)
 
-## Current: v0.1.0 — Paper Release
+## Planned: v0.1.0 — Paper Release
 
-v0.1.0 is the version cited in the Nature/Science paper. All 5 capabilities proven by integration tests and BDD scenarios.
+v0.1.0 will be the version cited in the paper. All 5 capabilities proven by integration tests and BDD scenarios.
 
 | Capability | Criteria | Status |
 |-----------|---------|--------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,7 +185,7 @@ curl http://127.0.0.1:18800/api/health
 
 ## Proven Capabilities
 
-LabClaw v0.1.0 demonstrates five core capabilities with reproducible benchmarks:
+LabClaw demonstrates five core capabilities with reproducible benchmarks:
 
 | Capability | What it proves | Metric |
 |:-----------|:---------------|:-------|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "labclaw"
-version = "0.1.0"
+version = "0.0.10"
 description = "Distributed agentic architecture for self-documenting, self-improving neuroscience laboratories"
 readme = "README.md"
 license = "Apache-2.0"
@@ -123,7 +123,7 @@ exclude_lines = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.1.0"
+version = "0.0.10"
 version_files = ["pyproject.toml:project.version"]
 tag_format = "v$version"
 update_changelog_on_bump = true

--- a/uv.lock
+++ b/uv.lock
@@ -1170,7 +1170,7 @@ wheels = [
 
 [[package]]
 name = "labclaw"
-version = "0.1.0"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Revert project version from `0.1.0` to `0.0.10` in pyproject.toml + commitizen
- Update docs/index.md to not claim v0.1.0 is current
- Change ROADMAP.md from "Current: v0.1.0" to "Planned: v0.1.0"
- Plugin example versions (0.1.0) left as-is — those are plugin versions, not project

## Test plan
- [x] `pyproject.toml` shows `version = "0.0.10"`
- [x] `uv.lock` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)