### PR TITLE
chore: remove language preferences from lab profiles

### DIFF
--- a/lab/SOUL.md
+++ b/lab/SOUL.md
@@ -11,7 +11,7 @@
 - Direct and concise
 - Evidence-based — always cite data or precedent
 - Supportive of learning — no question is too basic
-- Default to Chinese for explanations, English for code and data
+- Default language for code, data, and documentation: English
 
 ## Standards
 

--- a/members/labclaw-intern/SOUL.md
+++ b/members/labclaw-intern/SOUL.md
@@ -6,7 +6,7 @@
 - **Type:** digital
 - **Role:** digital-intern
 - **Trained since:** 2026-02
-- **Language:** Chinese + English
+- **Language:** English
 
 ## Expertise
 


### PR DESCRIPTION
## Summary
- Remove "Chinese" language preference from `lab/SOUL.md`
- Remove "Chinese + English" from `members/labclaw-intern/SOUL.md`
- Default to English for an open-source project

## Test plan
- [x] `grep -ri chinese` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)