### PR TITLE
chore: remove SAM-Behavior references

### DIFF
--- a/.claude/agents/edge-engineer.md
+++ b/.claude/agents/edge-engineer.md
@@ -27,4 +27,4 @@ Key constraints:
 - Quality checks must be fast (real-time or near-real-time during acquisition)
 - Never move or modify raw data files — only read and generate metadata/quality reports
 - Device adapters follow the plugin manifest pattern (manifest.yaml + capability declarations)
-- Support for SAM-Behavior as a video analysis backend (pose estimation, animal detection)
+- Support for video analysis backends (pose estimation, animal detection) via plugins

--- a/.claude/agents/neuro-specialist.md
+++ b/.claude/agents/neuro-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: neuro-specialist
-description: "Use this agent for neuroscience domain decisions: experiment graph schema design, NWB/BIDS data format compliance, analysis pipeline definitions (pose estimation, spike sorting, calcium imaging), subject/animal tracking schemas, behavioral paradigm modeling, or integration with neuroscience tools (DeepLabCut, Suite2p, Kilosort, SAM-Behavior, Pynapple, MNE-Python)."
+description: "Use this agent for neuroscience domain decisions: experiment graph schema design, NWB/BIDS data format compliance, analysis pipeline definitions (pose estimation, spike sorting, calcium imaging), subject/animal tracking schemas, behavioral paradigm modeling, or integration with neuroscience tools (DeepLabCut, Suite2p, Kilosort, Pynapple, MNE-Python)."
 model: sonnet
 ---
 
@@ -8,7 +8,7 @@ You are a neuroscience domain specialist for LabClaw, with expertise in behavior
 
 Your domain:
 - `plugins/schemas/` — Graph schema extensions for neuroscience data types
-- `plugins/analysis/` — Analysis pipeline wrappers (SAM-Behavior, DLC, Suite2p, Kilosort)
+- `plugins/analysis/` — Analysis pipeline wrappers (DLC, Suite2p, Kilosort)
 - NWB (Neurodata Without Borders) compliance for all data schemas
 - BIDS (Brain Imaging Data Structure) compatibility where applicable
 - Experiment design patterns for behavior + imaging labs
@@ -21,8 +21,7 @@ You ensure the system speaks the language of neuroscience. Your responsibilities
 - Ensure closed-loop optimization targets are scientifically meaningful and safe
 
 Key neuroscience tools you integrate:
-- **SAM-Behavior**: Zero-shot multi-animal pose estimation (primary video analysis)
-- **DeepLabCut**: Markerless pose estimation (alternative/validation)
+- **DeepLabCut**: Markerless pose estimation
 - **Suite2p**: Two-photon calcium imaging analysis
 - **Kilosort**: Spike sorting for electrophysiology
 - **NeuroConv**: Format conversion to NWB (47+ formats)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ Before submitting a pull request, verify:
 | Memory system: markdown, knowledge graph, search, shared blocks | memory-engineer | Building/modifying memory/*, lab/*, members/* |
 | Agent runtime, orchestrator, tool calling, LLM integration | agent-engineer | Building/modifying agents/runtime, orchestrator, prompts |
 | Edge nodes, file watchers, quality checks, device adapters, gateway | edge-engineer | Building/modifying edge/*, gateway, adapters/ |
-| Neuroscience domain: NWB, analysis pipelines, data schemas, SAM-Behavior | neuro-specialist | NWB export, analysis pipeline design, schema definitions |
+| Neuroscience domain: NWB, analysis pipelines, data schemas | neuro-specialist | NWB export, analysis pipeline design, schema definitions |
 | Discovery pipeline: mining, hypothesis, modeling, optimization, validation | discovery-engineer | Building/modifying discovery/, optimization/, validation/ |
 | Dashboard pages, Streamlit UI, visualization | platform-engineer | Building/modifying dashboard/ components |
 | Code review, PR review, security audit | code-reviewer | All code changes before merge |
@@ -172,7 +172,6 @@ Before submitting a pull request, verify:
 - **Graphiti**: `graphiti-core` — temporal knowledge graph for lab memory
 - **NWB**: `pynwb` + `hdmf` — Neurodata Without Borders export
 - **NeuroConv**: Format conversion from 47+ neuroscience formats
-- **SAM-Behavior**: Zero-shot multi-animal pose estimation ()
 - **watchdog**: File system monitoring for edge nodes
 - **scikit-optimize**: Bayesian optimization engine
 - **sentence-transformers**: Embedding model for memory search

--- a/tests/integration/test_memory_tiers.py
+++ b/tests/integration/test_memory_tiers.py
@@ -25,14 +25,14 @@ class TestTierA:
         entry = MemoryEntry(
             timestamp=datetime.now(UTC),
             category="experiment",
-            detail="Ran behavioral tracking with SAM-Behavior model",
+            detail="Ran behavioral tracking with DeepLabCut model",
         )
         backend.append_memory("lab", entry)
 
-        results = backend.search("SAM-Behavior")
+        results = backend.search("DeepLabCut")
         assert len(results) >= 1
         assert results[0].entity_id == "lab"
-        assert "SAM-Behavior" in results[0].snippet
+        assert "DeepLabCut" in results[0].snippet
 
     def test_write_soul_and_read(self, tmp_path: Path) -> None:
         backend = TierABackend(root=tmp_path)


### PR DESCRIPTION
## Summary
- Remove SAM-Behavior from neuro-specialist agent, edge-engineer agent, CLAUDE.md
- Replace test fixture with DeepLabCut (generic neuroscience tool)

## Test plan
- [x] `grep -ri sam-behavior` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)