### PR TITLE
chore(infra): non-root Docker, SHA-pin docs CI, gitignore

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@a2a8b00df0aa22a77a33ee5f956c2128661fabeb # v7
         with:
           enable-cache: true
 
@@ -41,7 +41,7 @@ jobs:
         run: uv run mkdocs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: site
 
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ data/
 *.bin
 *.dat
 
+# Databases
+*.sqlite
+*.sqlite3
+*.db
+
 # OS
 .DS_Store
 Thumbs.db

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,3 +17,5 @@ We are committed to a respectful, inclusive community. Contributors are expected
 ## Enforcement
 
 Project maintainers may remove comments, close issues/PRs, or block contributors for violations.
+
+To report violations, contact: conduct@labclaw.dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ WORKDIR /app
 COPY --from=builder /build/wheels/*.whl /tmp/wheels/
 RUN pip install --no-cache-dir /tmp/wheels/*.whl && rm -rf /tmp/wheels
 
+RUN useradd --create-home --shell /bin/bash labclaw
+USER labclaw
+WORKDIR /app
+
 EXPOSE 18800 18801
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  labclaw:
+    build: .
+    ports:
+      - "18800:18800"
+      - "18801:18801"
+    volumes:
+      - ./data:/app/data
+      - ./lab:/app/lab
+    environment:
+      - LABCLAW_DATA_DIR=/app/data
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

- **B6**: Add non-root `labclaw` user to Dockerfile
- **S5**: SHA-pin all 4 actions in `docs.yml` (matching ci.yml pattern)
- **S8**: Add `*.sqlite`, `*.sqlite3`, `*.db` to `.gitignore`
- **S6**: Add `docker-compose.yml` for local dev
- **S3**: Add contact email to `CODE_OF_CONDUCT.md`

## Test plan

- [x] `uv run pytest --cov=labclaw --cov-fail-under=100 -q` — 2166 passed, 100% coverage
- [ ] `docker build .` succeeds (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)