### PR TITLE
test(bdd): assert p < 0.05 in C1 DISCOVER and C2 EVOLVE

### DIFF
--- a/tests/features/step_definitions/paper_capabilities_steps.py
+++ b/tests/features/step_definitions/paper_capabilities_steps.py
@@ -249,7 +249,9 @@ def finding_with_significance(bdd_data_rows: list[dict[str, Any]]) -> None:
     validator = StatisticalValidator()
     cfg = ValidationConfig(min_sample_size=2)
     stat_result = validator.run_test("permutation", speed_vals, angle_vals, config=cfg)
-    assert 0.0 <= stat_result.p_value <= 1.0, f"p_value out of range: {stat_result.p_value}"
+    assert stat_result.p_value < 0.05, (
+        f"Expected p < 0.05 for C1 DISCOVER, got p={stat_result.p_value:.6f}"
+    )
 
 
 @then("fitness improvement is at least 15 percent")
@@ -278,7 +280,9 @@ def ablation_statistically_significant(bdd_evolution_result: dict[str, Any]) -> 
         ablation.fitness_scores,
         config=cfg,
     )
-    assert 0.0 <= stat_result.p_value <= 1.0
+    assert stat_result.p_value < 0.05, (
+        f"Expected p < 0.05 for C2 ablation, got p={stat_result.p_value:.6f}"
+    )
 
 
 @then("at least 90 percent of findings are retrievable")


### PR DESCRIPTION
## Summary

- **B9**: C1 DISCOVER BDD step now asserts `p < 0.05` (was only range-checking `0 ≤ p ≤ 1`)
- **B10**: C2 EVOLVE ablation BDD step now asserts `p < 0.05` (was only range-checking)

Both assertions pass on existing fixture data:
- C1: speed vs angle permutation test → p=0.000
- C2: full vs ablation fitness scores → p=0.000

## Test plan

- [x] `uv run pytest tests/features/layer3_engine/ -v` — all BDD scenarios pass
- [x] `uv run pytest --cov=labclaw --cov-fail-under=100 -q` — 2166 passed, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)