### PR TITLE
fix(types): resolve critical mypy errors, exclude plans from docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,9 @@ theme:
   icon:
     repo: fontawesome/brands/github
 
+exclude_docs: |
+  plans/
+
 plugins:
   - search
   - mkdocstrings:

--- a/src/labclaw/cli.py
+++ b/src/labclaw/cli.py
@@ -373,10 +373,11 @@ def _pipeline_cmd(args: list[str]) -> None:
         HypothesizeStep,
         ObserveStep,
         PredictStep,
+        ScientificStep,
     )
 
     conclude = ConcludeStep(memory_root=memory_root)
-    steps = [
+    steps: list[ScientificStep] = [
         ObserveStep(),
         AskStep(),
         HypothesizeStep(llm_provider=None, max_llm_calls=max_llm_calls),

--- a/src/labclaw/discovery/hypothesis.py
+++ b/src/labclaw/discovery/hypothesis.py
@@ -350,7 +350,8 @@ class LLMHypothesisGenerator:
         pattern_ids = [p.pattern_id for p in hypothesis_input.patterns]
         hypotheses: list[HypothesisOutput] = []
 
-        for item in response.hypotheses[:20]:
+        typed_response = _LLMHypothesisResponse.model_validate(response.model_dump())
+        for item in typed_response.hypotheses[:20]:
             statement = item.statement.strip()
             experiments = [e.strip() for e in item.required_experiments if e.strip()]
             if not statement:

--- a/src/labclaw/evolution/engine.py
+++ b/src/labclaw/evolution/engine.py
@@ -386,7 +386,7 @@ class EvolutionEngine:
         """Save all evolution state to JSON file."""
         state = EvolutionState(
             cycles=list(self._cycles.values()),
-            fitness_history=self._fitness.to_dict(),
+            fitness_history=self._fitness.to_dict(),  # type: ignore[arg-type]
         )
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(state.model_dump_json(indent=2))
@@ -398,7 +398,7 @@ class EvolutionEngine:
         try:
             state = EvolutionState.model_validate_json(path.read_text())
             self._cycles = {c.cycle_id: c for c in state.cycles}
-            self._fitness = FitnessTracker.from_dict(state.fitness_history)
+            self._fitness = FitnessTracker.from_dict(state.fitness_history)  # type: ignore[arg-type]
             logger.info(
                 "Loaded evolution state: %d cycles, %d fitness targets",
                 len(self._cycles),

--- a/src/labclaw/llm/providers/anthropic.py
+++ b/src/labclaw/llm/providers/anthropic.py
@@ -46,7 +46,10 @@ class AnthropicProvider:
             system=system or "You are a helpful assistant.",
             messages=[{"role": "user", "content": prompt}],
         )
-        return msg.content[0].text
+        block = msg.content[0]
+        if not hasattr(block, "text"):
+            raise ValueError(f"Unexpected content block type: {type(block).__name__}")
+        return block.text  # type: ignore[union-attr]
 
     async def complete_structured(
         self,

--- a/src/labclaw/orchestrator/loop.py
+++ b/src/labclaw/orchestrator/loop.py
@@ -80,10 +80,11 @@ class ScientificLoop:
     """7-step scientific method state machine."""
 
     def __init__(self, steps: list[ScientificStep] | None = None) -> None:
+        self._steps: list[ScientificStep]
         if steps is not None:
             self._steps = steps
         else:
-            self._steps: list[ScientificStep] = [
+            self._steps = [
                 ObserveStep(),
                 AskStep(),
                 HypothesizeStep(),

--- a/tests/unit/test_llm_providers.py
+++ b/tests/unit/test_llm_providers.py
@@ -234,6 +234,18 @@ class TestAnthropicProvider:
         assert result == "Hello from Claude"
 
     @pytest.mark.asyncio
+    async def test_complete_non_text_block_raises(self) -> None:
+        p = AnthropicProvider(api_key="test-key")
+
+        mock_block = MagicMock(spec=[])  # no attributes — simulates non-TextBlock
+        mock_msg = MagicMock()
+        mock_msg.content = [mock_block]
+
+        p._client.messages.create = AsyncMock(return_value=mock_msg)
+        with pytest.raises(ValueError, match="Unexpected content block type"):
+            await p.complete("Hi")
+
+    @pytest.mark.asyncio
     async def test_complete_structured(self) -> None:
         p = AnthropicProvider(api_key="test-key")
 


### PR DESCRIPTION
## Summary

- **S4**: Fix 5 mypy errors that could cause runtime bugs (36 → 20 remaining):
  - `hypothesis.py`: cast BaseModel to typed response before accessing `.hypotheses`
  - `anthropic.py`: guard against non-TextBlock content before accessing `.text`
  - `loop.py`: fix duplicate variable definition in conditional branches
  - `cli.py`: explicit `list[ScientificStep]` type annotation
  - `engine.py`: add `type: ignore` for Pydantic coercion patterns
- **S9**: Add `exclude_docs: plans/` to `mkdocs.yml` so internal plans aren't published

## Test plan

- [x] `uv run mypy src/labclaw/` — 20 errors (down from 36, remaining are cosmetic)
- [x] `uv run pytest --cov=labclaw --cov-fail-under=100 -q` — 2167 passed, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)