### PR TITLE
fix(security): remove pytest detection, fix actor spoofing, add body limits

### DIFF
--- a/src/labclaw/api/deps.py
+++ b/src/labclaw/api/deps.py
@@ -6,6 +6,7 @@ shares the same in-memory state (registry, chronicle, etc.).
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import secrets
@@ -141,21 +142,16 @@ def _env_bool(name: str, default: bool) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _running_under_pytest() -> bool:
-    return "PYTEST_CURRENT_TEST" in os.environ
-
-
 def _auth_required() -> bool:
-    # Secure by default outside tests; tests can override with env.
-    return _env_bool("LABCLAW_API_AUTH_REQUIRED", not _running_under_pytest())
+    return _env_bool("LABCLAW_API_AUTH_REQUIRED", True)
 
 
 def _governance_required() -> bool:
-    return _env_bool("LABCLAW_GOVERNANCE_ENFORCE", not _running_under_pytest())
+    return _env_bool("LABCLAW_GOVERNANCE_ENFORCE", True)
 
 
 def _rate_limit_enabled() -> bool:
-    return _env_bool("LABCLAW_RATE_LIMIT_ENABLED", not _running_under_pytest())
+    return _env_bool("LABCLAW_RATE_LIMIT_ENABLED", True)
 
 
 @lru_cache
@@ -294,9 +290,12 @@ async def enforce_request_security(request: Request) -> None:
 
     if _governance_required():
         action = _map_action_from_request(request)
-        actor = request.headers.get("x-labclaw-actor", "api-client")
         presented = _extract_presented_token(request)
         role = _resolve_role_for_token(presented)
+        if presented:
+            actor = f"token-{hashlib.sha256(presented.encode()).hexdigest()[:8]}"
+        else:
+            actor = "anonymous"
         decision = get_governance_engine().check(
             action=action,
             actor=actor,

--- a/src/labclaw/api/routers/agents.py
+++ b/src/labclaw/api/routers/agents.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from labclaw.agents import (
     EXPERIMENT_DESIGNER_SYSTEM,
@@ -28,7 +28,7 @@ router = APIRouter()
 
 
 class ChatRequest(BaseModel):
-    message: str
+    message: str = Field(max_length=10_000)
 
 
 class ChatResponse(BaseModel):

--- a/src/labclaw/api/routers/discovery.py
+++ b/src/labclaw/api/routers/discovery.py
@@ -20,14 +20,14 @@ router = APIRouter()
 
 
 class MineRequest(BaseModel):
-    data: list[dict[str, Any]]
+    data: list[dict[str, Any]] = Field(max_length=100_000)
     config: MiningConfig | None = None
 
 
 class HypothesizeRequest(BaseModel):
-    patterns: list[PatternRecord]
-    context: str = ""
-    constraints: list[str] = Field(default_factory=list)
+    patterns: list[PatternRecord] = Field(default_factory=list, max_length=10_000)
+    context: str = Field(default="", max_length=10_000)
+    constraints: list[str] = Field(default_factory=list, max_length=1_000)
 
 
 # ---------------------------------------------------------------------------

--- a/src/labclaw/api/routers/evolution.py
+++ b/src/labclaw/api/routers/evolution.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from labclaw.api.deps import get_evolution_engine
 from labclaw.core.schemas import EvolutionTarget
@@ -21,12 +21,12 @@ router = APIRouter()
 class FitnessRequest(BaseModel):
     target: EvolutionTarget
     metrics: dict[str, float]
-    data_points: int = 0
+    data_points: int = Field(default=0, ge=0, le=1_000_000)
 
 
 class CycleStartRequest(BaseModel):
     target: EvolutionTarget
-    n_candidates: int = 1
+    n_candidates: int = Field(default=1, ge=1, le=100)
 
 
 # ---------------------------------------------------------------------------

--- a/src/labclaw/api/routers/memory.py
+++ b/src/labclaw/api/routers/memory.py
@@ -6,7 +6,7 @@ import re
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from labclaw.api.deps import get_tier_a_backend
 from labclaw.memory.markdown import MemoryEntry, SearchResult, TierABackend
@@ -31,8 +31,8 @@ def _validate_entity_id_or_400(entity_id: str) -> None:
 
 
 class MemoryAppendRequest(BaseModel):
-    category: str
-    detail: str
+    category: str = Field(max_length=200)
+    detail: str = Field(max_length=10_000)
 
 
 # ---------------------------------------------------------------------------

--- a/src/labclaw/api/routers/orchestrator.py
+++ b/src/labclaw/api/routers/orchestrator.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from labclaw.orchestrator.loop import CycleResult
 
@@ -21,7 +21,7 @@ _MAX_CYCLE_HISTORY = 1000
 class CycleRequest(BaseModel):
     """Request body for triggering a cycle."""
 
-    data_rows: list[dict[str, Any]] = []
+    data_rows: list[dict[str, Any]] = Field(default_factory=list, max_length=100_000)
 
 
 @router.post("/cycle", status_code=201)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Root test configuration — shared fixtures for all test suites.
+
+Disables all security controls by default so that unit and BDD tests can
+exercise API behavior without needing real tokens, governance setup, or
+rate-limiting.  Individual security tests override these values explicitly
+via monkeypatch before calling reset_all().
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_security_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable auth, governance, and rate-limiting for every test by default.
+
+    Security-focused tests that need these enabled set the env vars explicitly
+    (via monkeypatch) and call deps.reset_all() themselves, which is the
+    existing pattern in tests/unit/test_api_security.py and the BDD step
+    definitions in tests/features/step_definitions/api_security_steps.py.
+    """
+    monkeypatch.setenv("LABCLAW_API_AUTH_REQUIRED", "0")
+    monkeypatch.setenv("LABCLAW_GOVERNANCE_ENFORCE", "0")
+    monkeypatch.setenv("LABCLAW_RATE_LIMIT_ENABLED", "0")

--- a/tests/unit/test_api_deps_coverage.py
+++ b/tests/unit/test_api_deps_coverage.py
@@ -190,3 +190,11 @@ class TestSecurityHelpersCoverage:
     def test_enforce_request_security_exempt_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("LABCLAW_RATE_LIMIT_ENABLED", "0")
         asyncio.run(deps.enforce_request_security(_request("/api/health")))
+
+    def test_env_bool_returns_default_when_env_var_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_env_bool returns the default value when the env var is not set (line 141)."""
+        monkeypatch.delenv("LABCLAW_API_AUTH_REQUIRED", raising=False)
+        assert deps._env_bool("LABCLAW_API_AUTH_REQUIRED", True) is True
+        assert deps._env_bool("LABCLAW_API_AUTH_REQUIRED", False) is False


### PR DESCRIPTION
## Summary

- **X1**: Remove `_running_under_pytest()` from auth/governance/rate-limit defaults — all default to `True` (secure). Tests use `autouse` fixture to override.
- **X2**: Actor identity derived from token hash (`token-{sha256[:8]}`), not from spoofable `X-Labclaw-Actor` header
- **X3**: Add `max_length`/`ge`/`le` constraints to all request body models (discovery, orchestrator, evolution, agents, memory)

## Test plan

- [x] `uv run pytest --cov=labclaw --cov-fail-under=100 -q` — 2169 passed, 100% coverage
- [x] Security tests that explicitly enable auth/governance still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)