### PR TITLE
fix(arch): add ORCHESTRATOR layer, protect API state, remove dead code

### DIFF
--- a/src/labclaw/api/app.py
+++ b/src/labclaw/api/app.py
@@ -114,13 +114,6 @@ app.include_router(
     tags=["orchestrator"],
     dependencies=_secure_dep,
 )
-# Provenance endpoints — both versioned and legacy prefixes
-app.include_router(
-    provenance_router,
-    prefix="/api/v0/provenance",
-    tags=["provenance"],
-    dependencies=_secure_dep,
-)
 app.include_router(
     provenance_router,
     prefix="/api/provenance",

--- a/src/labclaw/api/routers/orchestrator.py
+++ b/src/labclaw/api/routers/orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 # In-process cycle history (process-scoped; cleared on restart)
 _cycle_history: list[CycleResult] = []
+_cycle_history_lock = asyncio.Lock()
 _MAX_CYCLE_HISTORY = 1000
 
 
@@ -40,9 +42,10 @@ async def run_cycle(body: CycleRequest) -> CycleResult:
         logger.exception("Orchestrator cycle failed")
         raise HTTPException(status_code=500, detail="Internal server error") from exc
 
-    _cycle_history.append(result)
-    if len(_cycle_history) > _MAX_CYCLE_HISTORY:
-        del _cycle_history[0 : len(_cycle_history) - _MAX_CYCLE_HISTORY]
+    async with _cycle_history_lock:
+        _cycle_history.append(result)
+        if len(_cycle_history) > _MAX_CYCLE_HISTORY:
+            del _cycle_history[: len(_cycle_history) - _MAX_CYCLE_HISTORY]
     return result
 
 

--- a/src/labclaw/api/routers/provenance.py
+++ b/src/labclaw/api/routers/provenance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections import OrderedDict
 
 from fastapi import APIRouter, HTTPException
@@ -14,6 +15,7 @@ router = APIRouter()
 
 # In-process store (process-scoped; replaced by persistent store in v0.1.0)
 _chains: OrderedDict[str, ProvenanceChain] = OrderedDict()
+_chains_lock = asyncio.Lock()
 _MAX_CHAINS = 10_000
 
 
@@ -33,7 +35,7 @@ class ProvenanceRequest(BaseModel):
 
 
 @router.post("/", status_code=201)
-def create_provenance_chain(body: ProvenanceRequest) -> ProvenanceChain:
+async def create_provenance_chain(body: ProvenanceRequest) -> ProvenanceChain:
     """Register a provenance chain for a finding.
 
     Args:
@@ -58,11 +60,12 @@ def create_provenance_chain(body: ProvenanceRequest) -> ProvenanceChain:
         chain = tracker.build_chain(body.finding_id, steps)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="Invalid provenance chain") from exc
-    if body.finding_id in _chains:
-        _chains.move_to_end(body.finding_id)
-    _chains[body.finding_id] = chain
-    while len(_chains) > _MAX_CHAINS:
-        _chains.popitem(last=False)
+    async with _chains_lock:
+        if body.finding_id in _chains:
+            _chains.move_to_end(body.finding_id)
+        _chains[body.finding_id] = chain
+        while len(_chains) > _MAX_CHAINS:
+            _chains.popitem(last=False)
     return chain
 
 

--- a/src/labclaw/core/schemas.py
+++ b/src/labclaw/core/schemas.py
@@ -28,6 +28,7 @@ class Layer(StrEnum):
     MEMORY = "memory"
     PERSONA = "persona"
     EVOLUTION = "evolution"
+    ORCHESTRATOR = "orchestrator"
 
 
 class DeviceStatus(StrEnum):

--- a/src/labclaw/evolution/engine.py
+++ b/src/labclaw/evolution/engine.py
@@ -212,7 +212,7 @@ class EvolutionEngine:
         Emits ``evolution.cycle.advanced`` or ``evolution.cycle.rolled_back``.
         On promotion, also emits ``evolution.cycle.promoted``.
         """
-        cycle = self._get_cycle(cycle_id)
+        cycle = self.get_cycle(cycle_id)
 
         if cycle.stage == EvolutionStage.PROMOTED:
             raise ValueError(f"Cycle {cycle_id} already promoted")
@@ -275,7 +275,7 @@ class EvolutionEngine:
         Sets stage to ROLLED_BACK, records reason and completion time.
         Emits ``evolution.cycle.rolled_back``.
         """
-        cycle = self._get_cycle(cycle_id)
+        cycle = self.get_cycle(cycle_id)
 
         cycle.stage = EvolutionStage.ROLLED_BACK
         cycle.rollback_reason = reason
@@ -324,7 +324,7 @@ class EvolutionEngine:
         seconds) before it can advance.  For MVP this is generous — the daemon
         calls this each interval so a cycle will advance on the second tick.
         """
-        cycle = self._get_cycle(cycle_id)
+        cycle = self.get_cycle(cycle_id)
         elapsed = (datetime.now(UTC) - cycle.started_at).total_seconds()
         # Soak = at least 1 second (unit-test friendly) so that a brand-new
         # cycle created in the same tick is NOT immediately advanced.
@@ -419,11 +419,6 @@ class EvolutionEngine:
 
     # Private helpers
     # ------------------------------------------------------------------
-
-    def _get_cycle(self, cycle_id: str) -> EvolutionCycle:
-        if cycle_id not in self._cycles:
-            raise KeyError(f"Evolution cycle {cycle_id!r} not found")
-        return self._cycles[cycle_id]
 
     def _check_regression(
         self,

--- a/src/labclaw/memory/search.py
+++ b/src/labclaw/memory/search.py
@@ -131,7 +131,8 @@ class HybridSearchEngine:
 
     def _search_tier_a(self, query: HybridSearchQuery) -> list[HybridSearchResult]:
         """Search Tier A (markdown memory)."""
-        assert self._tier_a is not None
+        if self._tier_a is None:
+            raise RuntimeError("HybridSearchEngine: tier_a backend not configured")
         weight = self._config.tier_a_weight
         tier_a_results: list[SearchResult] = self._tier_a.search(query.text, limit=query.limit * 2)
 
@@ -152,7 +153,8 @@ class HybridSearchEngine:
 
     def _search_tier_b(self, query: HybridSearchQuery) -> list[HybridSearchResult]:
         """Search Tier B (knowledge graph)."""
-        assert self._tier_b is not None
+        if self._tier_b is None:
+            raise RuntimeError("HybridSearchEngine: tier_b backend not configured")
         weight = self._config.tier_b_weight
         kg_results = self._tier_b.search(query.text, limit=query.limit * 2)
 

--- a/tests/unit/test_api_provenance.py
+++ b/tests/unit/test_api_provenance.py
@@ -21,13 +21,13 @@ client = TestClient(app)
 
 
 # ---------------------------------------------------------------------------
-# POST /api/v0/provenance/
+# POST /api/provenance/
 # ---------------------------------------------------------------------------
 
 
 def test_create_chain_returns_201() -> None:
     resp = client.post(
-        "/api/v0/provenance/",
+        "/api/provenance/",
         json={
             "finding_id": "find-001",
             "steps": [
@@ -45,7 +45,7 @@ def test_create_chain_returns_201() -> None:
 
 def test_create_chain_empty_steps_returns_400() -> None:
     resp = client.post(
-        "/api/v0/provenance/",
+        "/api/provenance/",
         json={"finding_id": "find-002", "steps": []},
     )
     assert resp.status_code == 400
@@ -53,26 +53,26 @@ def test_create_chain_empty_steps_returns_400() -> None:
 
 
 # ---------------------------------------------------------------------------
-# GET /api/v0/provenance/{finding_id}
+# GET /api/provenance/{finding_id}
 # ---------------------------------------------------------------------------
 
 
 def test_get_chain_returns_200() -> None:
     # Create first
     client.post(
-        "/api/v0/provenance/",
+        "/api/provenance/",
         json={
             "finding_id": "find-get",
             "steps": [{"node_id": "n1", "node_type": "obs", "description": "d"}],
         },
     )
-    resp = client.get("/api/v0/provenance/find-get")
+    resp = client.get("/api/provenance/find-get")
     assert resp.status_code == 200
     assert resp.json()["finding_id"] == "find-get"
 
 
 def test_get_chain_not_found_returns_404() -> None:
-    resp = client.get("/api/v0/provenance/no-such-finding")
+    resp = client.get("/api/provenance/no-such-finding")
     assert resp.status_code == 404
 
 
@@ -115,7 +115,7 @@ def test_chain_preserves_all_steps() -> None:
         {"node_id": f"n{i}", "node_type": "stage", "description": f"step {i}"} for i in range(5)
     ]
     resp = client.post(
-        "/api/v0/provenance/",
+        "/api/provenance/",
         json={"finding_id": "find-multi", "steps": steps},
     )
     assert resp.status_code == 201
@@ -128,14 +128,14 @@ def test_recreating_same_finding_id_updates_chain_in_place() -> None:
         "finding_id": "same-id",
         "steps": [{"node_id": "n1", "node_type": "obs", "description": "v1"}],
     }
-    resp1 = client.post("/api/v0/provenance/", json=payload)
+    resp1 = client.post("/api/provenance/", json=payload)
     assert resp1.status_code == 201
 
     payload["steps"] = [{"node_id": "n2", "node_type": "obs", "description": "v2"}]
-    resp2 = client.post("/api/v0/provenance/", json=payload)
+    resp2 = client.post("/api/provenance/", json=payload)
     assert resp2.status_code == 201
 
-    got = client.get("/api/v0/provenance/same-id")
+    got = client.get("/api/provenance/same-id")
     assert got.status_code == 200
     assert got.json()["steps"][0]["node_id"] == "n2"
 
@@ -153,7 +153,7 @@ def test_chain_store_evicts_oldest_when_capacity_exceeded(
         "finding_id": "new",
         "steps": [{"node_id": "n2", "node_type": "obs", "description": "new"}],
     }
-    assert client.post("/api/v0/provenance/", json=first).status_code == 201
-    assert client.post("/api/v0/provenance/", json=second).status_code == 201
-    assert client.get("/api/v0/provenance/old").status_code == 404
-    assert client.get("/api/v0/provenance/new").status_code == 200
+    assert client.post("/api/provenance/", json=first).status_code == 201
+    assert client.post("/api/provenance/", json=second).status_code == 201
+    assert client.get("/api/provenance/old").status_code == 404
+    assert client.get("/api/provenance/new").status_code == 200

--- a/tests/unit/test_coverage_100.py
+++ b/tests/unit/test_coverage_100.py
@@ -1800,17 +1800,8 @@ def test_file_watcher_event_registration() -> None:
     assert event_registry.is_registered("hardware.file.detected")
 
 
-def test_evolution_get_cycle_unknown_id() -> None:
-    """Line 424: _get_cycle raises KeyError for unknown cycle_id."""
-    from labclaw.evolution.engine import EvolutionEngine
-
-    engine = EvolutionEngine()
-    with pytest.raises(KeyError, match="not found"):
-        engine._get_cycle("ghost-cycle-id")
-
-
 def test_evolution_get_cycle_public_api_unknown() -> None:
-    """Line 416: get_cycle (public) raises KeyError for unknown cycle_id."""
+    """get_cycle raises KeyError for unknown cycle_id."""
     from labclaw.evolution.engine import EvolutionEngine
 
     engine = EvolutionEngine()

--- a/tests/unit/test_memory_search.py
+++ b/tests/unit/test_memory_search.py
@@ -229,6 +229,22 @@ def test_search_tier_b_builds_snippet_from_name() -> None:
     assert results[0].snippet == "[session] plain-node"
 
 
+def test_search_tier_a_raises_runtime_error_when_backend_none() -> None:
+    """_search_tier_a raises RuntimeError if called with no tier_a backend."""
+    engine = HybridSearchEngine(tier_a=None)
+    query = HybridSearchQuery(text="test")
+    with pytest.raises(RuntimeError, match="tier_a backend not configured"):
+        engine._search_tier_a(query)
+
+
+def test_search_tier_b_raises_runtime_error_when_backend_none() -> None:
+    """_search_tier_b raises RuntimeError if called with no tier_b backend."""
+    engine = HybridSearchEngine(tier_b=None)
+    query = HybridSearchQuery(text="test")
+    with pytest.raises(RuntimeError, match="tier_b backend not configured"):
+        engine._search_tier_b(query)
+
+
 def test_search_both_tiers() -> None:
     """When both tiers are active, results from A and B are combined and sorted."""
     tier_a = MagicMock()


### PR DESCRIPTION
## Summary

- **A1**: Add `ORCHESTRATOR = "orchestrator"` to `Layer` enum — orchestrator events now correctly tagged
- **A5**: Add `asyncio.Lock()` to `_cycle_history` and `_chains` in API routers
- **L3**: Remove duplicate `_get_cycle()` method in `EvolutionEngine`
- **L8**: Replace bare `assert` in `memory/search.py` with `RuntimeError`
- **C5**: Remove `/api/v0/provenance` double-mount, keep only `/api/provenance`

## Test plan

- [x] `uv run pytest --cov=labclaw --cov-fail-under=100 -q` — 2168 passed, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)