### PR TITLE
fix(science): fix retrieval rate metric, fix session_ids in correlations

### DIFF
--- a/src/labclaw/discovery/mining.py
+++ b/src/labclaw/discovery/mining.py
@@ -163,7 +163,8 @@ class PatternMiner:
                 # Build paired observations — only rows where both columns exist
                 vals_a: list[float] = []
                 vals_b: list[float] = []
-                for row in data:
+                valid_indices: list[int] = []
+                for idx, row in enumerate(data):
                     if col_a in row and col_b in row:
                         try:
                             val_a = float(row[col_a])
@@ -172,6 +173,7 @@ class PatternMiner:
                             continue
                         vals_a.append(val_a)
                         vals_b.append(val_b)
+                        valid_indices.append(idx)
 
                 if len(vals_a) < 3:
                     continue
@@ -181,7 +183,7 @@ class PatternMiner:
                 p = float(p_val)
 
                 if abs(r) > threshold:
-                    session_ids = [str(row.get("session_id", idx)) for idx, row in enumerate(data)]
+                    session_ids = [str(data[i].get("session_id", i)) for i in valid_indices]
                     pattern = PatternRecord(
                         pattern_type="correlation",
                         description=(

--- a/src/labclaw/memory/session_memory.py
+++ b/src/labclaw/memory/session_memory.py
@@ -59,12 +59,40 @@ class SessionMemoryManager:
             _SQLiteFindingsStore(db_path) if db_path is not None else None
         )
         self._findings: list[dict[str, Any]] = []
+        self._total_stored_count: int = 0
+        self._loaded_count: int = 0
+        self._prior_stored_count: int = 0
+
+    @property
+    def _meta_path(self) -> Path:
+        return self._memory_root / _FINDINGS_ENTITY_ID / "META.json"
+
+    def _read_meta(self) -> int:
+        """Return persisted total_stored_count, or 0 if metadata file absent."""
+        if not self._meta_path.exists():
+            return 0
+        try:
+            data = json.loads(self._meta_path.read_text(encoding="utf-8"))
+            return int(data.get("total_stored_count", 0))
+        except (json.JSONDecodeError, ValueError):
+            return 0
+
+    def _write_meta(self) -> None:
+        """Persist total_stored_count to disk."""
+        self._meta_path.parent.mkdir(parents=True, exist_ok=True)
+        self._meta_path.write_text(
+            json.dumps({"total_stored_count": self._total_stored_count}),
+            encoding="utf-8",
+        )
 
     async def init(self) -> None:
         """Initialize backends and load existing findings from disk."""
         if self._tier_b is not None:
             await self._tier_b.init_db()
         self._findings = self._load_existing_findings()
+        self._prior_stored_count = self._read_meta()
+        self._total_stored_count = self._prior_stored_count
+        self._loaded_count = len(self._findings)
         event_registry.emit(
             "memory.session.initialized",
             payload={
@@ -149,6 +177,8 @@ class SessionMemoryManager:
             await self._tier_b.upsert_finding(finding)
 
         self._findings.append(finding)
+        self._total_stored_count += 1
+        self._write_meta()
 
         event_registry.emit(
             "memory.session.finding_stored",
@@ -186,17 +216,16 @@ class SessionMemoryManager:
         return [f for f in findings if q in json.dumps(f, default=str).lower()]
 
     def get_retrieval_rate(self) -> float:
-        """Compute fraction of stored findings that are currently retrievable.
+        """Compute fraction of previously stored findings retrieved on last init().
 
-        Compares the count loaded from disk during ``init()`` against total
-        in-memory list size.  Returns 1.0 when no findings have been stored.
+        ``_prior_stored_count`` is the count read from persisted META.json during
+        ``init()`` — it reflects findings written in *prior* sessions.
+        ``_loaded_count`` is the number actually loaded from disk during ``init()``.
+        Returns 1.0 when no findings existed before this session started.
         """
-        total = len(self._findings)
-        if total == 0:
+        if self._prior_stored_count == 0:
             return 1.0
-        # All findings in self._findings are retrievable (they were either
-        # loaded from disk or stored in this session and written to disk).
-        return 1.0
+        return self._loaded_count / self._prior_stored_count
 
     def is_known_pattern(self, pattern: dict[str, Any]) -> bool:
         """Return True if *pattern* matches any finding already stored.

--- a/tests/unit/test_discovery_mining_full.py
+++ b/tests/unit/test_discovery_mining_full.py
@@ -157,6 +157,28 @@ def test_correlation_uses_session_id_from_row() -> None:
     assert any("sess_" in sid for sid in patterns[0].session_ids)
 
 
+def test_correlation_session_ids_only_from_participating_rows() -> None:
+    """session_ids must only include rows where BOTH columns had valid values (C1 fix)."""
+    miner = PatternMiner()
+    # Rows 0–9: both x and y present; rows 10–14: only x present (y missing)
+    data = [
+        {"session_id": f"valid_{i}", "x": float(i), "y": float(i) * 2.0} for i in range(10)
+    ] + [
+        {"session_id": f"missing_y_{i}", "x": float(i)} for i in range(5)
+    ]
+    patterns = miner.find_correlations(data, threshold=0.5)
+    assert len(patterns) >= 1
+    xy_pattern = next(
+        p
+        for p in patterns
+        if p.evidence.get("col_a") == "x" and p.evidence.get("col_b") == "y"
+    )
+    # Only 10 valid rows participated; session_ids should not include missing_y_* entries
+    assert len(xy_pattern.session_ids) == 10
+    assert all(sid.startswith("valid_") for sid in xy_pattern.session_ids)
+    assert not any(sid.startswith("missing_y_") for sid in xy_pattern.session_ids)
+
+
 def test_anomaly_uses_session_id_from_row() -> None:
     miner = PatternMiner()
     data = [{"session_id": f"s{i}", "v": float(i)} for i in range(15)]

--- a/tests/unit/test_session_memory.py
+++ b/tests/unit/test_session_memory.py
@@ -203,6 +203,64 @@ class TestGetRetrievalRate:
         await mgr.store_finding(_finding(1))
         assert mgr.get_retrieval_rate() == 1.0
 
+    @pytest.mark.asyncio
+    async def test_rate_computed_not_hardcoded_across_sessions(self, tmp_path: Path) -> None:
+        """Rate = loaded_count / prior_stored_count; both values come from real tracking."""
+        memory_root = tmp_path / "mem"
+
+        # Session 1: store 3 findings
+        mgr1 = SessionMemoryManager(memory_root)
+        await mgr1.init()
+        for i in range(3):
+            await mgr1.store_finding(_finding(i))
+        assert mgr1._total_stored_count == 3
+
+        # Session 2: new manager loads from disk
+        mgr2 = SessionMemoryManager(memory_root)
+        await mgr2.init()
+        assert mgr2._loaded_count == 3
+        assert mgr2._prior_stored_count == 3
+        # All 3 were persisted and reloaded → rate == 1.0, but computed not hardcoded
+        assert mgr2.get_retrieval_rate() == 1.0
+
+    @pytest.mark.asyncio
+    async def test_rate_reflects_partial_retrieval(self, tmp_path: Path) -> None:
+        """If META.json claims 4 stored but only 2 load from MEMORY.md, rate = 0.5."""
+        import json
+
+        memory_root = tmp_path / "mem"
+
+        # Manually create META.json claiming 4 total stored
+        findings_dir = memory_root / "findings"
+        findings_dir.mkdir(parents=True)
+        (findings_dir / "META.json").write_text(
+            json.dumps({"total_stored_count": 4}), encoding="utf-8"
+        )
+        # But MEMORY.md only has 2 actual findings
+        (findings_dir / "MEMORY.md").write_text(
+            '## e1\n\n```json\n{"finding_id": "f1"}\n```\n'
+            '## e2\n\n```json\n{"finding_id": "f2"}\n```\n',
+            encoding="utf-8",
+        )
+        mgr = SessionMemoryManager(memory_root)
+        await mgr.init()
+        assert mgr._loaded_count == 2
+        assert mgr._prior_stored_count == 4
+        assert mgr.get_retrieval_rate() == 0.5
+
+    @pytest.mark.asyncio
+    async def test_read_meta_handles_corrupt_json(self, tmp_path: Path) -> None:
+        """_read_meta() returns 0 when META.json contains invalid JSON."""
+        memory_root = tmp_path / "mem"
+        findings_dir = memory_root / "findings"
+        findings_dir.mkdir(parents=True)
+        (findings_dir / "META.json").write_text("not json at all", encoding="utf-8")
+        mgr = SessionMemoryManager(memory_root)
+        await mgr.init()
+        # Corrupt meta → prior_stored_count defaults to 0 → rate == 1.0
+        assert mgr._prior_stored_count == 0
+        assert mgr.get_retrieval_rate() == 1.0
+
 
 # ---------------------------------------------------------------------------
 # is_known_pattern


### PR DESCRIPTION
## Summary

- **S2**: `SessionMemoryManager.get_retrieval_rate()` now tracks `_total_stored_count` via persisted `META.json`, compares loaded vs stored across restarts (was hardcoded 1.0)
- **C1**: `PatternRecord.session_ids` now only includes rows that participated in the correlation (was including all rows including those with missing values)

## Test plan

- [x] Cross-session retrieval rate test: store N → restart → verify rate = loaded/stored
- [x] Partial retrieval test: META says 4, only 2 loaded → rate = 0.5
- [x] Corrupt META.json graceful fallback test
- [x] Session IDs only from participating rows test
- [x] `uv run pytest --cov=labclaw --cov-fail-under=100 -q` — 2172 passed, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)