### PR TITLE
chore(deploy): add Caddy reverse proxy for demo server

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,23 @@
+# Caddyfile — LabClaw reverse proxy
+# Requires: LABCLAW_DOMAIN env var (e.g. demo.labclaw.io)
+# Caddy automatically provisions TLS via Let's Encrypt.
+
+{$LABCLAW_DOMAIN} {
+    # Security headers
+    header {
+        X-Frame-Options DENY
+        X-Content-Type-Options nosniff
+        Referrer-Policy strict-origin-when-cross-origin
+        -Server
+    }
+
+    # REST API
+    handle /api/* {
+        reverse_proxy localhost:18800
+    }
+
+    # Streamlit dashboard (catch-all)
+    handle /* {
+        reverse_proxy localhost:18801
+    }
+}

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # deploy.sh — Deploy LabClaw to a remote server
-# Usage: bash deploy/deploy.sh
+# Usage: LABCLAW_REMOTE=my-server bash deploy/deploy.sh
+# Optional: LABCLAW_DOMAIN=demo.labclaw.io bash deploy/deploy.sh
 set -euo pipefail
 
 # ── Config ──────────────────────────────────────────────────────────────────
-REMOTE="${LABCLAW_REMOTE:-labclaw-server}"  # SSH alias (configure in ~/.ssh/config)
+REMOTE="${LABCLAW_REMOTE:?Set LABCLAW_REMOTE to SSH host (e.g. export LABCLAW_REMOTE=my-server)}"
 REMOTE_DIR="/opt/labclaw"
 LOCAL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 REMOTE_IP=$(ssh "$REMOTE" 'hostname -I | awk "{print \$1}"')
@@ -181,6 +182,57 @@ echo ""
 echo "API:       http://localhost:18800/api/health"
 echo "Dashboard: http://localhost:18801"
 START
+
+# ── Step 7 (optional): Set up Caddy reverse proxy ─────────────────────────
+if [ -n "${LABCLAW_DOMAIN:-}" ]; then
+    echo "[7/7] Setting up Caddy reverse proxy for ${LABCLAW_DOMAIN}..."
+
+    # Upload Caddyfile with domain substituted
+    ssh "$REMOTE" "mkdir -p /etc/caddy"
+    sed "s/{\$LABCLAW_DOMAIN}/${LABCLAW_DOMAIN}/g" \
+        "${LOCAL_DIR}/deploy/Caddyfile" | ssh "$REMOTE" "cat > /etc/caddy/Caddyfile"
+
+    ssh "$REMOTE" bash -s <<'CADDY'
+set -euo pipefail
+
+# Install Caddy if not present
+if ! command -v caddy &>/dev/null; then
+    apt-get update -q
+    apt-get install -y -q debian-keyring debian-archive-keyring apt-transport-https curl
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+        | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+        | tee /etc/apt/sources.list.d/caddy-stable.list
+    apt-get update -q
+    apt-get install -y -q caddy
+    echo "Caddy installed"
+else
+    echo "Caddy already installed: $(caddy version)"
+fi
+
+# Allow HTTP/HTTPS through firewall
+if command -v ufw &>/dev/null; then
+    ufw allow 80/tcp
+    ufw allow 443/tcp
+    echo "Firewall: opened ports 80 and 443"
+fi
+
+# Enable and (re)start Caddy
+systemctl daemon-reload
+systemctl enable caddy
+systemctl restart caddy
+sleep 2
+systemctl status caddy --no-pager | head -10
+CADDY
+
+    echo ""
+    echo "  Caddy is running. TLS will be provisioned automatically."
+    echo "  API:       https://${LABCLAW_DOMAIN}/api/health"
+    echo "  Dashboard: https://${LABCLAW_DOMAIN}"
+else
+    echo "[7/7] LABCLAW_DOMAIN not set — skipping Caddy setup."
+    echo "  To enable TLS: re-run with LABCLAW_DOMAIN=your.domain.com"
+fi
 
 echo ""
 echo "╔══════════════════════════════════════════════════╗"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -181,12 +181,107 @@ The script:
 5. Initializes SOUL.md and MEMORY.md for the system entity.
 6. Installs and starts the systemd service.
 
-Customize the target by editing `deploy/deploy.sh`:
+Customize the target via environment variables:
 
 ```bash
-REMOTE="labclaw-server"          # SSH alias (or set LABCLAW_REMOTE env var)
-REMOTE_DIR="/opt/labclaw"        # Installation directory
+# Required: SSH host alias or user@host
+export LABCLAW_REMOTE=my-server
+
+# Optional: domain for automatic TLS (Caddy)
+export LABCLAW_DOMAIN=demo.labclaw.io
+
+bash deploy/deploy.sh
 ```
+
+---
+
+## Caddy Reverse Proxy (Automatic TLS)
+
+LabClaw services bind to `127.0.0.1` by default. Use Caddy as a reverse proxy to expose
+them over HTTPS with automatic certificate provisioning via Let's Encrypt.
+
+### Prerequisites
+
+- A domain name with an A record pointing to the server IP.
+- Ports 80 and 443 reachable from the internet (required by Let's Encrypt HTTP challenge).
+- The `LABCLAW_REMOTE` SSH alias configured.
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `LABCLAW_REMOTE` | Yes | SSH host (alias or `user@host`) |
+| `LABCLAW_DOMAIN` | No | Domain for TLS — if set, Caddy is installed and configured |
+
+### Automatic Setup via Deploy Script
+
+Set `LABCLAW_DOMAIN` before running `deploy.sh` and Caddy is installed automatically:
+
+```bash
+export LABCLAW_REMOTE=my-server
+export LABCLAW_DOMAIN=demo.labclaw.io
+bash deploy/deploy.sh
+```
+
+The script:
+
+1. Installs Caddy from the official Cloudsmith apt repository.
+2. Writes `/etc/caddy/Caddyfile` with routes for `/api/*` and `/*`.
+3. Opens ports 80 and 443 in `ufw`.
+4. Enables and starts the `caddy` systemd service.
+
+### Manual Setup
+
+Install Caddy on the server, copy the Caddyfile, and start the service:
+
+```bash
+# Upload and apply the Caddyfile
+scp deploy/Caddyfile my-server:/etc/caddy/Caddyfile
+ssh my-server "systemctl restart caddy"
+```
+
+### Caddyfile Reference
+
+The `deploy/Caddyfile` uses `{$LABCLAW_DOMAIN}` as a placeholder. When deploying
+manually, replace it with your domain or export the variable before starting Caddy:
+
+```bash
+export LABCLAW_DOMAIN=demo.labclaw.io
+caddy run --config /etc/caddy/Caddyfile
+```
+
+Routing rules:
+
+| Path | Upstream | Notes |
+|------|----------|-------|
+| `/api/*` | `localhost:18800` | FastAPI REST API |
+| `/*` | `localhost:18801` | Streamlit dashboard |
+
+Security headers set by Caddy on every response:
+
+| Header | Value |
+|--------|-------|
+| `X-Frame-Options` | `DENY` |
+| `X-Content-Type-Options` | `nosniff` |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` |
+| `Server` | (removed) |
+
+### Verify TLS
+
+After deployment, confirm the certificate is active:
+
+```bash
+curl -I https://demo.labclaw.io/api/health
+# Expect: HTTP/2 200
+```
+
+Check Caddy logs for certificate issuance:
+
+```bash
+ssh my-server "journalctl -u caddy -f"
+```
+
+Caddy renews certificates automatically before expiry — no cron job needed.
 
 ---
 


### PR DESCRIPTION
## Summary

- **`deploy/Caddyfile`** (new): Caddy config routing `/api/*` → `:18800` (FastAPI) and `/*` → `:18801` (Streamlit), with security headers (`X-Frame-Options DENY`, `X-Content-Type-Options nosniff`, `Referrer-Policy strict-origin-when-cross-origin`, `Server` header removed) and automatic TLS via Let's Encrypt using `{$LABCLAW_DOMAIN}` env var.
- **`deploy/deploy.sh`**: Replace silent `LABCLAW_REMOTE` fallback with `:?` (fails fast with a clear message if unset). Add optional step 7: when `LABCLAW_DOMAIN` is set, installs Caddy from the official Cloudsmith apt repo, writes `/etc/caddy/Caddyfile` with domain substituted, opens `ufw` ports 80/443, and enables the `caddy` systemd service.
- **`docs/deployment.md`**: New "Caddy Reverse Proxy (Automatic TLS)" section covering prerequisites, environment variables, automatic and manual setup, routing table, security headers table, and TLS verification steps.

## Notes

- `deploy/labclaw.service` unchanged — daemon already defaults to `127.0.0.1` binds.
- Caddy step is fully opt-in: if `LABCLAW_DOMAIN` is not set the script prints a hint and skips cleanly.
- `uv run ruff check src/` passes with no errors.

## Test plan

- [ ] Run `bash deploy/deploy.sh` without `LABCLAW_REMOTE` set — should fail immediately with the `:?` error message.
- [ ] Deploy to a test server with only `LABCLAW_REMOTE` set — Caddy step should be skipped (step 7 prints skip message).
- [ ] Deploy with both `LABCLAW_REMOTE` and `LABCLAW_DOMAIN` set — Caddy should be installed, `/etc/caddy/Caddyfile` written with domain, ports 80/443 open, service running.
- [ ] `curl -I https://$LABCLAW_DOMAIN/api/health` returns HTTP/2 200 with expected security headers.
- [ ] `curl -I https://$LABCLAW_DOMAIN/` proxies to Streamlit dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)