### PR TITLE
feat(daemon): add --dashboard-host bind option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ EXPOSE 18800 18801
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD python -c "import json,urllib.request; r=urllib.request.urlopen('http://localhost:18800/api/health'); d=json.load(r); raise SystemExit(0 if d.get('status')=='healthy' else 1)" || exit 1
 
-ENTRYPOINT ["labclaw", "serve", "--host", "0.0.0.0"]
+ENTRYPOINT ["labclaw", "serve", "--host", "0.0.0.0", "--dashboard-host", "0.0.0.0"]

--- a/src/labclaw/cli.py
+++ b/src/labclaw/cli.py
@@ -79,10 +79,11 @@ def main() -> None:
         print("  --api [PORT]   Launch FastAPI server only")
         print()
         print("Serve options (pass after 'serve'):")
-        print("  --data-dir PATH        Directory to watch (default: /opt/labclaw/data)")
-        print("  --memory-root PATH     Memory directory (default: /opt/labclaw/memory)")
-        print("  --port PORT            API port (default: 18800)")
-        print("  --dashboard-port PORT  Dashboard port (default: 18801)")
+        print("  --data-dir PATH          Directory to watch (default: /opt/labclaw/data)")
+        print("  --memory-root PATH       Memory directory (default: /opt/labclaw/memory)")
+        print("  --port PORT              API port (default: 18800)")
+        print("  --dashboard-port PORT    Dashboard port (default: 18801)")
+        print("  --dashboard-host HOST    Dashboard bind address (default: 127.0.0.1)")
 
 
 def _coerce_row_values(row: dict[str, str | None]) -> dict[str, Any]:

--- a/src/labclaw/daemon.py
+++ b/src/labclaw/daemon.py
@@ -155,6 +155,7 @@ class LabClawDaemon:
         host: str = "127.0.0.1",
         api_port: int = DEFAULT_PORT,
         dashboard_port: int = DASHBOARD_PORT,
+        dashboard_host: str = "127.0.0.1",
         discovery_interval: int = DISCOVERY_INTERVAL_SECONDS,
         evolution_interval: int = EVOLUTION_INTERVAL_SECONDS,
     ) -> None:
@@ -163,6 +164,7 @@ class LabClawDaemon:
         self.host = host
         self.api_port = api_port
         self.dashboard_port = dashboard_port
+        self.dashboard_host = dashboard_host
         self.discovery_interval = discovery_interval
         self.evolution_interval = evolution_interval
 
@@ -540,7 +542,7 @@ class LabClawDaemon:
                     "--server.port",
                     str(self.dashboard_port),
                     "--server.address",
-                    "127.0.0.1",
+                    self.dashboard_host,
                     "--server.headless",
                     "true",
                     "--browser.gatherUsageStats",
@@ -592,6 +594,12 @@ def main() -> None:
         help=f"Streamlit dashboard port (default: {DASHBOARD_PORT})",
     )
     parser.add_argument(
+        "--dashboard-host",
+        type=str,
+        default="127.0.0.1",
+        help="Streamlit dashboard bind address (default: 127.0.0.1)",
+    )
+    parser.add_argument(
         "--discovery-interval",
         type=int,
         default=DISCOVERY_INTERVAL_SECONDS,
@@ -617,6 +625,7 @@ def main() -> None:
         host=args.host,
         api_port=args.port,
         dashboard_port=args.dashboard_port,
+        dashboard_host=args.dashboard_host,
         discovery_interval=args.discovery_interval,
         evolution_interval=args.evolution_interval,
     )

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -148,6 +148,36 @@ def test_daemon_stop_kills_dashboard_after_timeout(tmp_path: Path) -> None:
     assert daemon._dashboard_log is None
 
 
+def test_dashboard_host_defaults_to_localhost(tmp_path: Path) -> None:
+    daemon = LabClawDaemon(
+        data_dir=tmp_path / "data",
+        memory_root=tmp_path / "memory",
+    )
+    assert daemon.dashboard_host == "127.0.0.1"
+
+
+def test_dashboard_host_custom_value_passed_to_streamlit(tmp_path: Path) -> None:
+    from unittest.mock import MagicMock, patch
+
+    daemon = LabClawDaemon(
+        data_dir=tmp_path / "data",
+        memory_root=tmp_path / "memory",
+        dashboard_host="0.0.0.0",
+    )
+    assert daemon.dashboard_host == "0.0.0.0"
+
+    mock_proc = MagicMock()
+    with patch("labclaw.daemon.subprocess.Popen", return_value=mock_proc) as mock_popen:
+        daemon._start_dashboard()
+
+    call_args = mock_popen.call_args[0][0]
+    addr_idx = call_args.index("--server.address")
+    assert call_args[addr_idx + 1] == "0.0.0.0"
+
+    if daemon._dashboard_log:
+        daemon._dashboard_log.close()
+
+
 def test_tier_a_backend_rejects_path_traversal_entity_ids(tmp_path: Path) -> None:
     backend = TierABackend(root=tmp_path / "memory")
     entry = MemoryEntry(timestamp=datetime.now(UTC), category="note", detail="x")


### PR DESCRIPTION
## Summary

- Add `dashboard_host: str = "127.0.0.1"` parameter to `LabClawDaemon.__init__()` and store it as `self.dashboard_host`
- Replace hardcoded `"127.0.0.1"` in `_start_dashboard()` with `self.dashboard_host` so the Streamlit subprocess binds to the configured address
- Add `--dashboard-host` CLI argument to `daemon.py` `main()` argparser (default `127.0.0.1`) and pass it through to `LabClawDaemon`
- Update `cli.py` serve help text to document the new option
- Update `Dockerfile` ENTRYPOINT to pass `--dashboard-host 0.0.0.0` so Docker containers expose the dashboard on all interfaces

## Test plan

- [x] `test_dashboard_host_defaults_to_localhost` — verifies default value is `127.0.0.1`
- [x] `test_dashboard_host_custom_value_passed_to_streamlit` — verifies `0.0.0.0` reaches `subprocess.Popen` args at `--server.address`
- [x] `uv run pytest --cov=labclaw --cov-fail-under=100 -x -q` — 2179 passed, 100% coverage
- [x] `uv run ruff check` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)