### PR TITLE
fix(config): normalize dict/BaseModel LLM configs from YAML

### DIFF
--- a/src/labclaw/config.py
+++ b/src/labclaw/config.py
@@ -75,9 +75,14 @@ class LabClawConfig(BaseModel):
     agents: AgentsConfig = AgentsConfig()
 
     def model_post_init(self, __context: Any) -> None:
+        cls = _get_llm_config_class()
         if self.llm is None:
-            cls = _get_llm_config_class()
             self.llm = cls()
+        elif isinstance(self.llm, dict):
+            self.llm = cls(**self.llm)
+        elif not isinstance(self.llm, cls):
+            # Mismatched BaseModel — convert via model_dump then re-validate
+            self.llm = cls(**self.llm.model_dump())
 
 
 def load_config(path: Path | None = None) -> LabClawConfig:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,7 +13,9 @@ from labclaw.config import (
     EventsConfig,
     GraphConfig,
     LabClawConfig,
+    LLMConfigFallback,
     SystemConfig,
+    _get_llm_config_class,
     load_config,
 )
 
@@ -107,3 +109,51 @@ class TestNestedConfigModels:
         ac = AgentsConfig(default_model="gpt-4", max_tool_calls=50)
         assert ac.default_model == "gpt-4"
         assert ac.max_tool_calls == 50
+
+
+class TestLLMConfigNormalization:
+    """model_post_init must coerce dict / mismatched BaseModel → expected LLM type."""
+
+    def test_dict_llm_config_is_normalized(self):
+        """A plain dict under `llm` should be coerced to the LLM config class."""
+        cls = _get_llm_config_class()
+        raw = {"provider": "openai", "model": "gpt-4o", "api_key_env": "OPENAI_API_KEY"}
+        cfg = LabClawConfig(llm=raw)
+        assert isinstance(cfg.llm, cls)
+        assert cfg.llm.provider == "openai"
+        assert cfg.llm.model == "gpt-4o"
+
+    def test_mismatched_basemodel_is_normalized(self):
+        """A BaseModel that is not the expected LLM class is converted via model_dump."""
+        cls = _get_llm_config_class()
+        # LLMConfigFallback has the same fields as LLMConfig (or IS LLMConfig when
+        # llm.provider is available).  Using it as a "mismatched" source works in
+        # either case because we check `not isinstance(self.llm, cls)`.
+        fallback = LLMConfigFallback(provider="local", model="llama-3", api_key_env="NONE")
+        if isinstance(fallback, cls):
+            # When llm.provider is unavailable, cls IS LLMConfigFallback → no mismatch.
+            # Construct a genuinely mismatched model using another BaseModel subclass.
+            from pydantic import BaseModel as PydanticBaseModel
+
+            class _OtherModel(PydanticBaseModel):
+                provider: str = "local"
+                model: str = "llama-3"
+                api_key_env: str = "NONE"
+                temperature: float = 0.5
+                max_tokens: int = 512
+
+            mismatched = _OtherModel()
+        else:
+            mismatched = fallback
+
+        cfg = LabClawConfig(llm=mismatched)
+        assert isinstance(cfg.llm, cls)
+        assert cfg.llm.provider == "local"
+        assert cfg.llm.model == "llama-3"
+
+    def test_correct_model_passes_through_unchanged(self):
+        """An already-correct LLM config instance is kept as-is."""
+        cls = _get_llm_config_class()
+        correct = cls(provider="anthropic", model="claude-opus-4-6")
+        cfg = LabClawConfig(llm=correct)
+        assert cfg.llm is correct


### PR DESCRIPTION
## Summary

- `model_post_init` in `LabClawConfig` now handles all three YAML-load cases for the `llm` field: `None` (default), `dict` (raw YAML), and a mismatched `BaseModel` instance
- Normalization uses `_get_llm_config_class()` so it works with both `LLMConfig` (from `llm.provider`) and the fallback `LLMConfigFallback`
- Three new unit tests in `TestLLMConfigNormalization` cover each branch

## Changed files

- `src/labclaw/config.py` — 5-line addition in `model_post_init`
- `tests/unit/test_config.py` — 50-line addition (`TestLLMConfigNormalization` class)

## Test plan

- [x] `uv run pytest tests/unit/test_config.py -v` — 15 passed
- [x] `uv run pytest --cov=labclaw --cov-fail-under=100 -x -q` — 2179 passed, 100% coverage
- [x] `uv run ruff check src/labclaw/config.py tests/unit/test_config.py` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)