### PR TITLE
fix(ci): only push Docker images on version tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
- Docker build succeeds but push to ghcr.io returns 403 (registry not configured yet)
- Change `push: true` → push only on version tags (`refs/tags/v*`)
- Main branch pushes now build-only (validates Dockerfile without pushing)

## Test plan
- [ ] Docker workflow passes on this PR (build-only, no push)
- [ ] Docker workflow on main goes green after merge
- [ ] When a `v*` tag is pushed, Docker image is pushed to ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)